### PR TITLE
Added Headless Browser support

### DIFF
--- a/sel3.py
+++ b/sel3.py
@@ -4,12 +4,16 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.firefox.options import Options
 import time
-driver=webdriver.Firefox()
+
+options = Options()
+options.add_argument("--headless")
+driver=webdriver.Firefox(firefox_options=options)
 driver.get("https://www.facebook.com")
 wait = WebDriverWait(driver, 600)
 email=driver.find_element_by_id('email')
-email.send_keys('Your email goes here')
+email.send_keys('Your email/phone_number goes here')
 print("Email Entered")
 pwd=driver.find_element_by_id('pass')
 pwd.send_keys('Your password goes here')


### PR DESCRIPTION
Automatic opening of the Firefox window seemed to be a useless side-effect due invocation of the geckodriver through selenium. Henceforth added a few lines in the script to do the requisite job without opening the Firefox browser window that is 'Headless Mode'.  